### PR TITLE
Filter out WorkoutActivity

### DIFF
--- a/src/logic/export_parser.py
+++ b/src/logic/export_parser.py
@@ -193,8 +193,6 @@ class ExportParser:
                 self._process_workout_statistics(child, record)
             elif child.tag == "MetadataEntry":
                 self._process_metadata_entry(child, record)
-            elif child.tag == "WorkoutActivity":
-                self._process_workout_children(child, record, zipfile)
             elif child.tag == "WorkoutRoute":
                 self._process_workout_route(child, record, zipfile)
 


### PR DESCRIPTION
This pull request ensures that data within `WorkoutActivity` elements is ignored during the parsing process and adds a corresponding test to verify this behavior. The main focus is to prevent statistics and metadata nested inside `WorkoutActivity` from being loaded into the workout record.

Parsing logic changes:

* Updated `_process_workout_children` in `export_parser.py` to skip processing of `WorkoutActivity` children, ensuring that statistics and metadata within these elements are ignored.

Testing:

* Added a new test `test_workout_activity_stats_and_metadata_are_ignored` in `test_export_parser_complex.py` to confirm that data inside `WorkoutActivity` does not appear in the parsed workout record.