### PR TITLE
Fix: clean the dev file name from the storage when it is not passed in parameter

### DIFF
--- a/src/apple_health_analyzer.py
+++ b/src/apple_health_analyzer.py
@@ -203,6 +203,8 @@ def cli_main() -> None:
     if resolved_path is not None:
         app.storage.general["_dev_file_path"] = str(resolved_path)
         _logger.debug("Stored dev file path in app storage: %s", resolved_path)
+    else:
+        app.storage.general["_dev_file_path"] = None
 
     _logger.debug("Initializing NiceGUI app")
     ui.run(  # type: ignore[misc]

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -428,6 +428,30 @@ class TestCLIArgumentParsing:
             finally:
                 apple_health_analyzer.app.storage.general.pop("_dev_file_path", None)
 
+    def test_cli_main_sets_dev_file_path_to_none_without_dev_file(
+        self, clean_logger: logging.Logger, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that cli_main explicitly stores None when no dev file is provided."""
+        assert clean_logger is logging.getLogger()
+        monkeypatch.setattr(sys, "argv", ["apple_health_analyzer.py"])
+
+        with (
+            patch("apple_health_analyzer.setup_logging") as mock_setup_logging,
+            patch("apple_health_analyzer.ui.run") as mock_ui_run,
+        ):
+            try:
+                apple_health_analyzer.cli_main()
+                storage_general = cast(
+                    dict[str, str | None], apple_health_analyzer.app.storage.general
+                )
+                assert "_dev_file_path" in storage_general
+                assert storage_general["_dev_file_path"] is None
+                mock_setup_logging.assert_called_once()
+                assert mock_setup_logging.call_args[1]["enable_file_logging"] is True
+                mock_ui_run.assert_called_once()
+            finally:
+                apple_health_analyzer.app.storage.general.pop("_dev_file_path", None)
+
     def test_cli_main_dev_file_not_found_exits(  # pylint: disable=unused-argument
         self, clean_logger: logging.Logger, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
This pull request improves how the application handles the absence of a development file by explicitly storing `None` in the app storage and adds a corresponding test to ensure this behavior. The main changes are grouped into enhancements to app storage handling and test coverage.

App storage handling:

* Modified `cli_main` in `src/apple_health_analyzer.py` to explicitly store `None` in `app.storage.general["_dev_file_path"]` when no development file is provided.

Test coverage:

* Added `test_cli_main_sets_dev_file_path_to_none_without_dev_file` in `tests/test_logging_setup.py` to verify that `cli_main` sets `_dev_file_path` to `None` when no development file is given, and checks related logging and UI run behavior.…provided