### PR TITLE
Specify Python version range for SonarCloud analysis

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,0 @@
-sonar.python.version=3.14

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,6 +10,7 @@ sonar.projectName=apple-health-analyzer
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=src
 sonar.tests=tests
+sonar.python.version=3.10,3.11,3.12,3.13,3.14
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
This pull request updates the Python version configuration for SonarCloud analysis. The most important changes are:

**SonarCloud configuration:**

* Removed the `sonar.python.version` property from `.sonarcloud.properties` to avoid redundancy and potential conflicts.
* Added `sonar.python.version=3.10,3.11,3.12,3.13,3.14` to `sonar-project.properties` to explicitly specify support for multiple Python versions in SonarCloud analysis.