### PR TITLE
fix: add environment variable for PyPI publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -459,6 +459,7 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     if: ${{ !inputs.dry_run && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) }}
+    environment: ${{ vars.PYPI_ENVIRONMENT || 'pypi' }}
     needs:
       - release
     permissions:


### PR DESCRIPTION
This pull request makes a small update to the `release.yml` workflow. It sets the deployment environment for the "Publish to PyPI" job dynamically, using the `PYPI_ENVIRONMENT` variable if available, or defaulting to `'pypi'`.