### PR TITLE
fix(workflow): standardize version scheme to non-zero-padded month format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          current_month=$(date +%Y.%m)
+          current_month=$(date +%Y.%-m)
           last_tag=$(git tag -l "v${current_month}.*" | sort -V | tail -n 1)
           if [ -z "$last_tag" ]; then
             last_patch=0

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -161,19 +161,19 @@ Runtime notes:
 
 ## Release Process
 
-TrackTales uses **Calendar Versioning (CalVer)** with the format `YYYY.MM.PATCH` (e.g., `2026.05.1`, `2026.05.2`).
+TrackTales uses **Calendar Versioning (CalVer)** with the format `YYYY.M.PATCH` (e.g., `2026.5.1`, `2026.5.2`).
 
 ### Versioning Scheme
 
 - **YYYY**: Current year (4 digits)
-- **MM**: Current month (2 digits, zero-padded)
+- **M**: Current month (non-zero-padded)
 - **PATCH**: Sequential patch number within the month, auto-incremented (starts at 1)
 
 Examples:
 
-- First release in May 2026: `v2026.05.1`
-- Second release in May 2026: `v2026.05.2`
-- First release in June 2026: `v2026.06.1`
+- First release in May 2026: `v2026.5.1`
+- Second release in May 2026: `v2026.5.2`
+- First release in June 2026: `v2026.6.1`
 
 ### How to Release
 
@@ -194,13 +194,13 @@ Examples:
    - Set **Dry run** if you want to build and validate without publishing
    - Click **Run workflow** button
 5. **Workflow automatically**:
-   - Calculates next version (YYYY.MM.PATCH with auto-incremented PATCH)
+   - Calculates next version (YYYY.M.PATCH with auto-incremented PATCH)
    - Updates and commits `pyproject.toml` with the new version before creating the release tag
    - Builds Windows executable (.exe) via PyInstaller
    - Builds macOS app bundle (.dmg) via PyInstaller
    - Builds Python distributions (.whl and .tar.gz) via setuptools
    - Runs full test suite
-   - Creates git tag (e.g., `v2026.05.2`)
+   - Creates git tag (e.g., `v2026.5.2`)
    - Creates GitHub Release with:
      - Installation instructions for each platform
      - Auto-generated changelog from commits since last release
@@ -235,7 +235,7 @@ python tools/release_dry_run.py --keep-temp
 
 The script:
 
-- Computes the next `YYYY.MM.PATCH` version from local git tags
+- Computes the next `YYYY.M.PATCH` version from local git tags
 - Copies the repo to a temporary workspace
 - Rewrites `pyproject.toml` there with the computed release version
 - Optionally builds Python distributions, runs tests, and builds PyInstaller artifacts
@@ -248,7 +248,7 @@ After release, end-users can install TrackTales:
 
 - **Windows**: Download `.exe` from GitHub Releases, double-click to run (no installation needed)
 - **macOS**: Download `.dmg` from GitHub Releases, double-click and drag app to Applications folder
-- **Python/pip**: `pip install tracktales==YYYY.MM.PATCH` (from PyPI)
+- **Python/pip**: `pip install tracktales==YYYY.M.PATCH` (from PyPI)
 
 ### Building Standalone Executables Locally
 
@@ -304,7 +304,7 @@ If this smoke test fails with a traceback, include the full stack trace in the i
 
    ```bash
    pip install create-dmg
-   create-dmg --volname "TrackTales" --app-drop-link 450 250 "dist/tracktales-YYYY.MM.PATCH.dmg" "dist/tracktales.app"
+   create-dmg --volname "TrackTales" --app-drop-link 450 250 "dist/tracktales-YYYY.M.PATCH.dmg" "dist/tracktales.app"
    ```
 
 ### PyInstaller Configuration
@@ -354,7 +354,7 @@ No API tokens need to be stored in GitHub secrets; the workflow uses OpenID Conn
 **Need to release a hotfix immediately**:
 
 - No manual version management needed; just push commits and trigger the workflow again
-- The workflow auto-increments PATCH (2026.05.1 → 2026.05.2 → etc.)
+- The workflow auto-increments PATCH (2026.5.1 → 2026.5.2 → etc.)
 
 **Rollback strategy**:
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,9 +11,9 @@ def _raise(exc: BaseException) -> None:
 
 
 def test_get_version_uses_installed_distribution(monkeypatch) -> None:
-    monkeypatch.setattr(version, "package_version", lambda _name: "2026.05.2")
+    monkeypatch.setattr(version, "package_version", lambda _name: "2026.5.2")
 
-    assert version._get_version() == "2026.05.2"
+    assert version._get_version() == "2026.5.2"
 
 
 def test_get_version_falls_back_to_pyproject(monkeypatch, tmp_path: Path) -> None:
@@ -21,10 +21,10 @@ def test_get_version_falls_back_to_pyproject(monkeypatch, tmp_path: Path) -> Non
     src_dir = tmp_path / "src"
     src_dir.mkdir()
     pyproject_path = tmp_path / "pyproject.toml"
-    pyproject_path.write_text('[project]\nversion = "2026.05.3"\n', encoding="utf-8")
+    pyproject_path.write_text('[project]\nversion = "2026.5.3"\n', encoding="utf-8")
     monkeypatch.setattr(version, "__file__", str(src_dir / "version.py"))
 
-    assert version._get_version() == "2026.05.3"
+    assert version._get_version() == "2026.5.3"
 
 
 def test_get_version_returns_dev_when_pyproject_missing_or_unreadable(
@@ -38,7 +38,7 @@ def test_get_version_returns_dev_when_pyproject_missing_or_unreadable(
     assert version._get_version() == "0.0.0.dev"
 
     pyproject_path = tmp_path / "pyproject.toml"
-    pyproject_path.write_text('[project]\nversion = "2026.05.4"\n', encoding="utf-8")
+    pyproject_path.write_text('[project]\nversion = "2026.5.4"\n', encoding="utf-8")
     monkeypatch.setattr(Path, "read_text", lambda *_args, **_kwargs: _raise(OSError()))
 
     assert version._get_version() == "0.0.0.dev"

--- a/tools/release_dry_run.py
+++ b/tools/release_dry_run.py
@@ -37,7 +37,7 @@ def git_output(args: list[str], cwd: Path) -> str:
 
 
 def compute_version(root: Path) -> tuple[str, str, str]:
-    current_month = datetime.now().strftime("%Y.%m")
+    current_month = datetime.now().strftime("%Y.%-m")
     tags = git_output(["tag", "-l", "--sort=version:refname", f"v{current_month}.*"], root)
     last_tag = tags.splitlines()[-1] if tags else ""
     last_patch = int(last_tag.rsplit(".", 1)[-1]) if last_tag else 0


### PR DESCRIPTION
This pull request updates the CalVer versioning scheme across the project to use a non-zero-padded month format (`YYYY.M.PATCH`, e.g. `2026.6.1` instead of `2026.06.1`).

## Changes Made

- **`.github/workflows/release.yml`**: Changed `current_month` to use `%Y.%-m` for non-zero-padded month formatting.
- **`tools/release_dry_run.py`**: Updated `strftime("%Y.%m")` to `strftime("%Y.%-m")` so the local dry-run tool produces tags consistent with the workflow.
- **`MAINTAINERS.md`**: Updated the versioning scheme documentation from `YYYY.MM.PATCH` to `YYYY.M.PATCH`, changed the month description from "2 digits, zero-padded" to "non-zero-padded", and updated all version examples accordingly.
- **`tests/test_version.py`**: Aligned example version strings with the new non-zero-padded format.