### PR TITLE
fix(workflow): Add conditional checks for linting and type-checking

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,11 +48,13 @@ jobs:
           pip install -e .
 
       - name: Lint with Ruff
+        if: matrix.python-version == '3.14'
         run: |
           ruff format --check src tests
           ruff check src tests
 
       - name: Type-check with mypy
+        if: matrix.python-version == '3.14'
         run: |
           mypy src tests
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,14 +28,19 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
 
-      - name: Install dev dependencies (if present)
+      - name: Install dev dependencies (lint/type-check Python only)
+        if: matrix.python-version == '3.14'
         run: |
           if [ -f requirements-dev.txt ]; then
             pip install -r requirements-dev.txt
           else
-            # Minimal tooling if no dev requirements file exists
-            pip install pytest pytest-cov ruff mypy
+            pip install pytest pytest-asyncio pytest-cov ruff mypy
           fi
+
+      - name: Install test dependencies (other Python versions)
+        if: matrix.python-version != '3.14'
+        run: |
+          pip install pytest pytest-asyncio pytest-cov
 
       - name: Install runtime dependencies (if present)
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ i18n = ["locales/**/*.po", "locales/**/*.mo", "locales/**/*.pot", "locales/READM
 [tool.mypy]
 mypy_path = "src"
 explicit_package_bases = true
-python_version = "3.10"
+python_version = "3.14"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false


### PR DESCRIPTION
This pull request updates the test workflow configuration to only run linting and type-checking steps for Python 3.14. This helps optimize CI resources by skipping these steps for other Python versions and avoid crashes as this does not work for version under python 3.12

CI workflow optimization:

* [`.github/workflows/tests.yml`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR51-R57): Added a condition to the "Lint with Ruff" and "Type-check with mypy" steps so they only run when `matrix.python-version` is `3.14`.