### PR TITLE
fix(workflow): enhance auto-merge workflow for Dependabot PRs with me…

### DIFF
--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -15,17 +15,20 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
+    # Only run for Dependabot PRs that are not drafts, ensuring security and relevance.
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && !github.event.pull_request.draft }}
+    env:
+      PR_URL: ${{github.event.pull_request.html_url}}
+      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     steps:
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      # Check for merge conflicts to ensure the PR is in a stable state before merging.
       - name: Check whether PR is mergeable
         id: mergeability
         run: |
-          set -euo pipefail
+          set -euo pipefail # Exit immediately if a command fails, and treat unset variables as errors.
           state="$(gh pr view "$PR_URL" --json mergeStateStatus --jq '.mergeStateStatus')"
           echo "merge_state=$state" >> "$GITHUB_OUTPUT"
           if [ "$state" = "DIRTY" ]; then
@@ -35,12 +38,8 @@ jobs:
             echo "mergeable=true" >> "$GITHUB_OUTPUT"
             echo "PR mergeStateStatus=$state, auto-merge can proceed."
           fi
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      # Only attempt to merge if the previous step confirmed mergeability.
       - name: Enable auto-merge for Dependabot PRs
         if: ${{ steps.mergeability.outputs.mergeable == 'true' }}
         run: gh pr merge --auto --rebase "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -1,6 +1,12 @@
 name: Auto-merge Dependabot PRs
 
-on: pull_request
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: dependabot-automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -9,14 +15,31 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && !github.event.pull_request.draft }}
     steps:
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Check whether PR is mergeable
+        id: mergeability
+        run: |
+          set -euo pipefail
+          state="$(gh pr view "$PR_URL" --json mergeStateStatus --jq '.mergeStateStatus')"
+          echo "merge_state=$state" >> "$GITHUB_OUTPUT"
+          if [ "$state" = "DIRTY" ]; then
+            echo "mergeable=false" >> "$GITHUB_OUTPUT"
+            echo "PR has merge conflicts (mergeStateStatus=DIRTY), skipping auto-merge."
+          else
+            echo "mergeable=true" >> "$GITHUB_OUTPUT"
+            echo "PR mergeStateStatus=$state, auto-merge can proceed."
+          fi
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Enable auto-merge for Dependabot PRs
+        if: ${{ steps.mergeability.outputs.mergeable == 'true' }}
         run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -21,9 +21,6 @@ jobs:
       PR_URL: ${{github.event.pull_request.html_url}}
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     steps:
-      - name: Approve a PR
-        run: gh pr review --approve "$PR_URL"
-
       # Check for merge conflicts to ensure the PR is in a stable state before merging.
       - name: Check whether PR is mergeable
         id: mergeability
@@ -46,6 +43,10 @@ jobs:
             echo "mergeable=true" >> "$GITHUB_OUTPUT"
             echo "PR mergeStateStatus=$state, auto-merge can proceed."
           fi
+
+      - name: Approve a PR
+        if: ${{ steps.mergeability.outputs.mergeable == 'true' }}
+        run: gh pr review --approve "$PR_URL"
 
       # Only attempt to merge if the previous step confirmed mergeability.
       - name: Enable auto-merge for Dependabot PRs

--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -29,11 +29,19 @@ jobs:
         id: mergeability
         run: |
           set -euo pipefail # Exit immediately if a command fails, and treat unset variables as errors.
-          state="$(gh pr view "$PR_URL" --json mergeStateStatus --jq '.mergeStateStatus')"
+
+          # mergeStateStatus can be temporarily UNKNOWN right after PR events; retry briefly for a stable value.
+          for i in {1..10}; do
+            state="$(gh pr view "$PR_URL" --json mergeStateStatus --jq '.mergeStateStatus')"
+            [ "$state" != "UNKNOWN" ] && break
+            echo "mergeStateStatus=UNKNOWN, retrying ($i/10)..."
+            sleep 3
+          done
+
           echo "merge_state=$state" >> "$GITHUB_OUTPUT"
-          if [ "$state" = "DIRTY" ]; then
+          if [ "$state" = "DIRTY" ] || [ "$state" = "UNKNOWN" ]; then
             echo "mergeable=false" >> "$GITHUB_OUTPUT"
-            echo "PR has merge conflicts (mergeStateStatus=DIRTY), skipping auto-merge."
+            echo "PR mergeStateStatus=$state, skipping auto-merge."
           else
             echo "mergeable=true" >> "$GITHUB_OUTPUT"
             echo "PR mergeStateStatus=$state, auto-merge can proceed."

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -60,3 +60,4 @@ jobs:
              echo "✅ Successfully validated commit messages for $checked commit(s) in $rev_range."
           elif [ "$checked" -eq 0 ]; then
             echo "⚠️ No non-empty commits found to validate in $rev_range."
+          fi

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -20,9 +20,10 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install Commitizen
+      - name: Setup and Install Dependencies
         run: |
-          python -m pip install -r requirements-dev.txt
+          # Install commit validation tools from development requirements
+          pip install -r requirements-dev.txt
 
       - name: Validate commit messages (pull request)
         shell: bash
@@ -35,20 +36,27 @@ jobs:
           checked=0
           while IFS= read -r sha; do
             [ -z "$sha" ] && continue
-            
+
             # Skip empty commits (e.g., merge commits if any sneaked in)
             if [ -z "$(git diff-tree --no-commit-id --name-only -r "$sha")" ]; then
               echo "Skipping empty commit: $sha"
               continue
             fi
-            
+
             # Extract and check the commit message
-            msg="$(git log -1 --pretty=%B "$sha")"
-            cz check --message "$msg"
+            message="$(git log -1 --pretty=%B "$sha")"
+            if ! cz check --message "$message"; then
+                echo "❌ Validation failed for commit $sha. Conventional Commit format violation."
+                exit 1 # Fail the workflow immediately upon finding a bad commit
+            fi
+
             checked=$((checked + 1))
-            
+
+
           done < <(git rev-list --reverse "$rev_range")
 
-          if [ "$checked" -eq 0 ]; then
-            echo "No non-empty commits to validate in $rev_range"
-          fi
+          # Final status output based on checks performed.
+          if [ "$checked" -gt 0 ]; then
+             echo "✅ Successfully validated commit messages for $checked commit(s) in $rev_range."
+          elif [ "$checked" -eq 0 ]; then
+            echo "⚠️ No non-empty commits found to validate in $rev_range."

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -14,53 +14,65 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
-      - name: Setup and Install Dependencies
+      - name: Install Commitizen
         run: |
-          # Install commit validation tools from development requirements
           python -m pip install -r requirements-dev.txt
 
-      - name: Validate commit messages (pull request)
+      - name: Validate commit messages (push)
+        if: github.event_name == 'push'
         shell: bash
         run: |
           set -euo pipefail
-
-          # Compare the branch starting point (base) to the latest commit (head)
-          rev_range="${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
+          before="${{ github.event.before }}"
+          if [ "$before" = "0000000000000000000000000000000000000000" ]; then
+            rev_range="HEAD~20..HEAD"
+          else
+            rev_range="$before..${{ github.sha }}"
+          fi
 
           checked=0
           while IFS= read -r sha; do
             [ -z "$sha" ] && continue
-
-            # Skip empty commits (commits with no file changes)
             if [ -z "$(git diff-tree --no-commit-id --name-only -r "$sha")" ]; then
               echo "Skipping empty commit: $sha"
               continue
             fi
-
-            # Extract and check the commit message
-            message="$(git log -1 --pretty=%B "$sha")"
-            if ! cz check --message "$message"; then
-                echo "❌ Validation failed for commit $sha. Conventional Commit format violation."
-                exit 1 # Fail the workflow immediately upon finding a bad commit
-            fi
-
+            msg="$(git log -1 --pretty=%B "$sha")"
+            cz check --message "$msg"
             checked=$((checked + 1))
-
-
           done < <(git rev-list --reverse "$rev_range")
 
-          # Final status output based on checks performed.
-          if [ "$checked" -gt 0 ]; then
-             echo "✅ Successfully validated commit messages for $checked commit(s) in $rev_range."
-          elif [ "$checked" -eq 0 ]; then
-            echo "⚠️ No non-empty commits found to validate in $rev_range."
+          if [ "$checked" -eq 0 ]; then
+            echo "No non-empty commits to validate in $rev_range"
+          fi
+
+      - name: Validate commit messages (pull request)
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          rev_range="${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
+          checked=0
+          while IFS= read -r sha; do
+            [ -z "$sha" ] && continue
+            if [ -z "$(git diff-tree --no-commit-id --name-only -r "$sha")" ]; then
+              echo "Skipping empty commit: $sha"
+              continue
+            fi
+            msg="$(git log -1 --pretty=%B "$sha")"
+            cz check --message "$msg"
+            checked=$((checked + 1))
+          done < <(git rev-list --reverse "$rev_range")
+
+          if [ "$checked" -eq 0 ]; then
+            echo "No non-empty commits to validate in $rev_range"
           fi

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,6 +1,9 @@
 name: Conventional Commits
 
 on:
+  push:
+    branches:
+      - "**"
   pull_request:
 
 permissions:

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup and Install Dependencies
         run: |
           # Install commit validation tools from development requirements
-          pip install -r requirements-dev.txt
+          python -m pip install -r requirements-dev.txt
 
       - name: Validate commit messages (pull request)
         shell: bash

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,9 +1,6 @@
 name: Conventional Commits
 
 on:
-  push:
-    branches:
-      - "**"
   pull_request:
 
 permissions:
@@ -14,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
@@ -27,50 +24,29 @@ jobs:
         run: |
           python -m pip install -r requirements-dev.txt
 
-      - name: Validate commit messages (push)
-        if: github.event_name == 'push'
-        shell: bash
-        run: |
-          set -euo pipefail
-          before="${{ github.event.before }}"
-          if [ "$before" = "0000000000000000000000000000000000000000" ]; then
-            rev_range="HEAD~20..HEAD"
-          else
-            rev_range="$before..${{ github.sha }}"
-          fi
-
-          checked=0
-          while IFS= read -r sha; do
-            [ -z "$sha" ] && continue
-            if [ -z "$(git diff-tree --no-commit-id --name-only -r "$sha")" ]; then
-              echo "Skipping empty commit: $sha"
-              continue
-            fi
-            msg="$(git log -1 --pretty=%B "$sha")"
-            cz check --message "$msg"
-            checked=$((checked + 1))
-          done < <(git rev-list --reverse "$rev_range")
-
-          if [ "$checked" -eq 0 ]; then
-            echo "No non-empty commits to validate in $rev_range"
-          fi
-
       - name: Validate commit messages (pull request)
-        if: github.event_name == 'pull_request'
         shell: bash
         run: |
           set -euo pipefail
+
+          # Compare the branch starting point (base) to the latest commit (head)
           rev_range="${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
+
           checked=0
           while IFS= read -r sha; do
             [ -z "$sha" ] && continue
+            
+            # Skip empty commits (e.g., merge commits if any sneaked in)
             if [ -z "$(git diff-tree --no-commit-id --name-only -r "$sha")" ]; then
               echo "Skipping empty commit: $sha"
               continue
             fi
+            
+            # Extract and check the commit message
             msg="$(git log -1 --pretty=%B "$sha")"
             cz check --message "$msg"
             checked=$((checked + 1))
+            
           done < <(git rev-list --reverse "$rev_range")
 
           if [ "$checked" -eq 0 ]; then

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -37,7 +37,7 @@ jobs:
           while IFS= read -r sha; do
             [ -z "$sha" ] && continue
 
-            # Skip empty commits (e.g., merge commits if any sneaked in)
+            # Skip empty commits (commits with no file changes)
             if [ -z "$(git diff-tree --no-commit-id --name-only -r "$sha")" ]; then
               echo "Skipping empty commit: $sha"
               continue


### PR DESCRIPTION
This pull request updates the Dependabot auto-merge GitHub Actions workflow to make the process more robust and reliable. The main improvements include expanding the workflow triggers, adding concurrency control, and ensuring PRs are only auto-merged if they are mergeable and not drafts.

**Workflow reliability and safety improvements:**

* The workflow now triggers on additional pull request events (`opened`, `synchronize`, `reopened`, `ready_for_review`), ensuring it responds to all relevant PR state changes.
* Added a concurrency group to prevent multiple auto-merge jobs from running simultaneously on the same PR, which helps avoid race conditions.
* The workflow now checks that the PR is not a draft and is opened by `dependabot[bot]` before proceeding, making the merge process safer.
* Introduced a step to check the PR's mergeability using the `mergeStateStatus` from the GitHub API, and only enables auto-merge if the PR does not have merge conflicts.
* The auto-merge step is now conditional on the PR being mergeable, preventing failed or conflicted PRs from being auto-merged.…rgeability checks